### PR TITLE
DEV-968 make hathifiles date independent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     milemarker (1.0.0)
     minitest (5.20.0)
     mysql2 (0.5.5)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -172,6 +174,7 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/jobs/generate_hathifile.rb
+++ b/jobs/generate_hathifile.rb
@@ -5,17 +5,22 @@ require "bib_record"
 require "date"
 require "settings"
 require "push_metrics"
+require "zephir_files"
 
 class GenerateHathifile
-  attr_reader :intype
-
-  def initialize(intype)
-    @intype = intype
+  def run
+    zephir_files = ZephirFiles.new(
+      zephir_dir: Settings.zephir_dir,
+      hathifiles_dir: Settings.hathifiles_dir
+    )
+    zephir_files.unprocessed.each do |zephir_file|
+      run_file zephir_file
+    end
   end
 
-  def run
-    tracker = PushMetrics.new(batch_size: 10_000, job_name: "generate_hathifile_#{intype}")
-    infile = Dir.glob(File.join(Settings.zephir_dir, "zephir_#{intype}*")).max
+  def run_file(zephir_file)
+    infile = File.join(Settings.zephir_dir, zephir_file.filename)
+    tracker = PushMetrics.new(batch_size: 10_000, job_name: "generate_hathifile_#{zephir_file.type}")
 
     fin = if /\.gz$/.match?(infile)
       Zlib::GzipReader.open(infile)
@@ -24,63 +29,66 @@ class GenerateHathifile
     end
 
     # we only want to write some of the items in the zephr records
-    indate = File.basename(infile).split("_")[2].split(".").first
-    cutoff = if /upd/.match?(infile)
-      # cutoff = Date.today.prev_day.strftime("%Y%m%d").to_i
-      indate.to_i - 1
+    cutoff = if zephir_file.type == "upd"
+      zephir_file.date.strftime("%Y%m%d").to_i
     else
       0
     end
 
-    # Hathifiles date is one day later than the Zephir file
-    outdate = Date.parse(indate).next_day.strftime("%Y%m%d")
-
-    outfile = File.join(Settings.hathifiles_dir, "hathi_#{intype}_#{outdate}.txt")
-    fout = File.open(outfile, "w")
+    outfile = File.join(Settings.hathifiles_dir, zephir_file.hathifile)
 
     puts "Infile: #{infile}"
     puts "Outfile: #{outfile}"
     puts "Cutoff: #{cutoff}"
 
-    fin.each do |line|
-      BibRecord.new(line).hathifile_records.each do |rec|
-        next unless rec[:update_date].to_i > cutoff.to_i
-        outrec = [rec[:htid],
-          rec[:access],
-          rec[:rights],
-          rec[:ht_bib_key],
-          rec[:description],
-          (rec[:source] || ""),
-          (rec[:source_bib_num].join(",") || ""),
-          rec[:oclc_num].join(","),
-          rec[:isbn].join(","),
-          rec[:issn].join(","),
-          rec[:lccn].join(","),
-          rec[:title].join(","),
-          rec[:imprint].join(", "),
-          (rec[:rights_reason_code] || ""),
-          (rec[:rights_timestamp]&.strftime("%Y-%m-%d %H:%M:%S") || ""),
-          rec[:us_gov_doc_flag],
-          rec[:rights_date_used],
-          rec[:pub_place],
-          rec[:lang],
-          rec[:bib_fmt],
-          (rec[:collection_code] || ""),
-          (rec[:content_provider_code] || ""),
-          (rec[:responsible_entity_code] || ""),
-          (rec[:digitization_agent_code] || ""),
-          (rec[:access_profile] || ""),
-          (rec[:author].join(", ") || "")]
-        fout.puts outrec.join("\t")
+    Tempfile.create do |fout|
+      fin.each do |line|
+        BibRecord.new(line).hathifile_records.each do |rec|
+          next unless rec[:update_date].to_i > cutoff.to_i
+          fout.puts record_from_bib_record(rec).join("\t")
+        end
+        tracker.increment_and_log_batch_line
       end
-      tracker.increment_and_log_batch_line
+      fout.flush
+      system("gzip #{fout.path}")
+      gzfile = fout.path + ".gz"
+      # Move tempfile into place
+      FileUtils.mv(gzfile, outfile)
     end
-
-    fout.close
-    system("gzip #{outfile}")
-
+    fin.close
     tracker.log_final_line
+  end
+
+  def record_from_bib_record(rec)
+    [
+      rec[:htid],
+      rec[:access],
+      rec[:rights],
+      rec[:ht_bib_key],
+      rec[:description],
+      (rec[:source] || ""),
+      (rec[:source_bib_num].join(",") || ""),
+      rec[:oclc_num].join(","),
+      rec[:isbn].join(","),
+      rec[:issn].join(","),
+      rec[:lccn].join(","),
+      rec[:title].join(","),
+      rec[:imprint].join(", "),
+      (rec[:rights_reason_code] || ""),
+      (rec[:rights_timestamp]&.strftime("%Y-%m-%d %H:%M:%S") || ""),
+      rec[:us_gov_doc_flag],
+      rec[:rights_date_used],
+      rec[:pub_place],
+      rec[:lang],
+      rec[:bib_fmt],
+      (rec[:collection_code] || ""),
+      (rec[:content_provider_code] || ""),
+      (rec[:responsible_entity_code] || ""),
+      (rec[:digitization_agent_code] || ""),
+      (rec[:access_profile] || ""),
+      (rec[:author].join(", ") || "")
+    ]
   end
 end
 
-GenerateHathifile.new(ARGV.shift).run if __FILE__ == $PROGRAM_NAME
+GenerateHathifile.new.run if __FILE__ == $PROGRAM_NAME

--- a/lib/zephir_file.rb
+++ b/lib/zephir_file.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "date"
+
+class ZephirFile
+  attr_reader :filename
+
+  def initialize(filename)
+    @filename = File.basename(filename)
+  end
+
+  def type
+    @type ||= filename.split("_")[1]
+  end
+
+  def date
+    @date ||= Date.parse(filename.split("_")[2].split(".").first)
+  end
+
+  # The corresponding hathifile
+  # Date is one day later than the Zephir file
+  def hathifile
+    "hathi_#{type}_#{date.next.strftime("%Y%m%d")}.txt.gz"
+  end
+end

--- a/lib/zephir_files.rb
+++ b/lib/zephir_files.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "zephir_file"
+
+class ZephirFiles
+  attr_reader :zephir_dir, :hathifiles_dir
+
+  def initialize(zephir_dir:, hathifiles_dir:)
+    @zephir_dir = zephir_dir
+    @hathifiles_dir = hathifiles_dir
+  end
+
+  def unprocessed
+    all.reject do |zephir_file|
+      File.exist? File.join(hathifiles_dir, zephir_file.hathifile)
+    end
+  end
+
+  def all
+    Dir.glob(File.join(zephir_dir, "zephir_{full,upd}*")).map do |zephir_file|
+      ZephirFile.new(zephir_file)
+    end
+  end
+end

--- a/spec/jobs/generate_hathifile_spec.rb
+++ b/spec/jobs/generate_hathifile_spec.rb
@@ -24,11 +24,24 @@ RSpec.describe GenerateHathifile do
 
   it "generates the expected output" do
     # One particular UC record from a day in August 2022
-    system("cp #{__dir__}/../data/000018677-20220807.json #{Settings.zephir_dir}/zephir_test_20220807.json")
+    system("cp #{__dir__}/../data/000018677-20220807.json #{Settings.zephir_dir}/zephir_full_20220807.json")
 
-    GenerateHathifile.new("test").run
+    GenerateHathifile.new.run
 
-    outfile = "#{Settings.hathifiles_dir}/hathi_test_20220808.txt.gz"
+    outfile = "#{Settings.hathifiles_dir}/hathi_full_20220808.txt.gz"
+    generated = Zlib::GzipReader.open(outfile).read
+    # The items as they were output on that day
+    expected = File.read("#{__dir__}/../data/000018677-20220808.tsv")
+    expect(generated).to eq(expected)
+  end
+
+  it "generates the expected output from gzipped file" do
+    # One particular UC record from a day in August 2022
+    system("cp #{__dir__}/../data/000018677-20220807.json #{Settings.zephir_dir}/zephir_full_20220807.json")
+    system("gzip #{Settings.zephir_dir}/zephir_full_20220807.json")
+    GenerateHathifile.new.run
+
+    outfile = "#{Settings.hathifiles_dir}/hathi_full_20220808.txt.gz"
     generated = Zlib::GzipReader.open(outfile).read
     # The items as they were output on that day
     expected = File.read("#{__dir__}/../data/000018677-20220808.tsv")
@@ -41,11 +54,11 @@ RSpec.describe GenerateHathifile do
 
     # run as above
     # One particular UC record from a day in August 2022
-    system("cp #{__dir__}/../data/000018677-20220807.json #{Settings.zephir_dir}/zephir_test_20220807.json")
-    GenerateHathifile.new("test").run
+    system("cp #{__dir__}/../data/000018677-20220807.json #{Settings.zephir_dir}/zephir_full_20220807.json")
+    GenerateHathifile.new.run
     metrics = Faraday.get("#{pm_endpoint}/metrics").body
 
-    expect(metrics).to match(/^job_last_success\S*job="generate_hathifile_test"\S* \S+/m)
-      .and match(/^job_records_processed\S*job="generate_hathifile_test"\S* 1$/m)
+    expect(metrics).to match(/^job_last_success\S*job="generate_hathifile_full"\S* \S+/m)
+      .and match(/^job_records_processed\S*job="generate_hathifile_full"\S* 1$/m)
   end
 end

--- a/spec/jobs/generate_hathifile_spec.rb
+++ b/spec/jobs/generate_hathifile_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe GenerateHathifile do
     GenerateHathifile.new.run
     metrics = Faraday.get("#{pm_endpoint}/metrics").body
 
-    expect(metrics).to match(/^job_last_success\S*job="generate_hathifile_full"\S* \S+/m)
-      .and match(/^job_records_processed\S*job="generate_hathifile_full"\S* 1$/m)
+    expect(metrics).to match(/^job_last_success\S*job="generate_hathifiles"\S* \S+/m)
+      .and match(/^job_records_processed\S*job="generate_hathifiles"\S* 1$/m)
   end
 end

--- a/spec/jobs/update_hathifile_listing_spec.rb
+++ b/spec/jobs/update_hathifile_listing_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "faraday"
 require "spec_helper"
 require_relative "../../jobs/update_hathifile_listing"
 

--- a/spec/zephir_file_spec.rb
+++ b/spec/zephir_file_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "date"
+require "spec_helper"
+require "zephir_file"
+
+TEST_ZEPHIR_FILE = "zephir_test_20090101.json.gz"
+TEST_ZEPHIR_PATH = "/app/#{TEST_ZEPHIR_FILE}"
+TEST_ZEPHIR_DATE = "2009-01-01"
+TEST_ZEPHIR_HATHIFILE = "hathi_test_20090102.txt.gz"
+
+RSpec.describe ZephirFile do
+  let(:zephir_file) { described_class.new(TEST_ZEPHIR_PATH) }
+
+  describe "#initialize" do
+    context "with a bare filename" do
+      it "uses the passed filename" do
+        zf = described_class.new(TEST_ZEPHIR_FILE)
+        expect(zf.filename).to eq(TEST_ZEPHIR_FILE)
+      end
+    end
+
+    context "with a path" do
+      it "parses the filename from the passed path" do
+        zf = described_class.new(TEST_ZEPHIR_PATH)
+        expect(zf.filename).to eq(TEST_ZEPHIR_FILE)
+      end
+    end
+  end
+
+  describe "#type" do
+    it "parses the type from the filename" do
+      expect(zephir_file.type).to eq("test")
+    end
+  end
+
+  describe "#date" do
+    it "parses the date from the filename" do
+      expect(zephir_file.date).to eq(Date.parse(TEST_ZEPHIR_DATE))
+    end
+  end
+
+  describe "#hathifile" do
+    it "returns the filled-in Hathifile template" do
+      expect(zephir_file.hathifile).to eq(TEST_ZEPHIR_HATHIFILE)
+    end
+  end
+end

--- a/spec/zephir_files_spec.rb
+++ b/spec/zephir_files_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "zephir_files"
+
+ZEPHIR_TEST_FIXTURES = [
+  "zephir_full_20090101.json.gz",
+  "zephir_upd_20090101.json.gz",
+  "zephir_upd_20090102.json.gz",
+  "zephir_upd_20090103.json.gz"
+].shuffle.freeze
+
+HATHIFILES_TEST_FIXTURES = [
+  "hathi_full_20090102.txt.gz", # based on pre-shuffle ZEPHIR_TEST_FIXTURES[0]
+  "hathi_upd_20090104.txt.gz"  # based on pre-shuffle ZEPHIR_TEST_FIXTURES[3]
+].shuffle.freeze
+
+ZEPHIR_UNPROCESSED_FIXTURES = [
+  "zephir_upd_20090101.json.gz", # pre-shuffle ZEPHIR_TEST_FIXTURES[1]
+  "zephir_upd_20090102.json.gz"  # pre-shuffle ZEPHIR_TEST_FIXTURES[2]
+].shuffle.freeze
+
+def with_zephir_files_test_fixtures
+  Dir.mktmpdir("zephir") do |zephir_dir|
+    Dir.mktmpdir("hathifiles") do |hathifiles_dir|
+      ZEPHIR_TEST_FIXTURES.each do |fixture|
+        `touch #{File.join(zephir_dir, fixture)}`
+      end
+      HATHIFILES_TEST_FIXTURES.each do |fixture|
+        `touch #{File.join(hathifiles_dir, fixture)}`
+      end
+      yield zephir_dir: zephir_dir, hathifiles_dir: hathifiles_dir
+    end
+  end
+end
+
+RSpec.describe ZephirFiles do
+  describe ".new" do
+    let(:zephir_files) {
+      described_class.new(zephir_dir: Settings.zephir_dir, hathifiles_dir: Settings.hathifiles_dir)
+    }
+    it "preserves zephir directory" do
+      expect(zephir_files.zephir_dir).to eq(Settings.zephir_dir)
+    end
+
+    it "preserves hathifiles directory" do
+      expect(zephir_files.hathifiles_dir).to eq(Settings.hathifiles_dir)
+    end
+  end
+
+  describe "#all" do
+    it "returns all of the zephir files in order" do
+      with_zephir_files_test_fixtures do |zephir_dir:, hathifiles_dir:|
+        @zf = described_class.new(zephir_dir: zephir_dir, hathifiles_dir: hathifiles_dir)
+        expect(@zf.all.map { |zf| zf.filename }).to eq(ZEPHIR_TEST_FIXTURES.sort)
+      end
+    end
+  end
+
+  describe "#unprocessed" do
+    it "returns all of the zephir files in order" do
+      with_zephir_files_test_fixtures do |zephir_dir:, hathifiles_dir:|
+        @zf = described_class.new(zephir_dir: zephir_dir, hathifiles_dir: hathifiles_dir)
+        expect(@zf.unprocessed.map { |zf| zf.filename }).to eq(ZEPHIR_UNPROCESSED_FIXTURES.sort)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- `generate_hathifile.rb` no longer takes an {upd,full} type but generates all missing hathifiles
- Use tempfile for generated hathifiles
- `ZephirFile` and `ZephirFiles` classes for determining agenda for hathifile generation