### PR TITLE
TTO-216 Hathifiles permissions are incorrect

### DIFF
--- a/jobs/generate_hathifile.rb
+++ b/jobs/generate_hathifile.rb
@@ -54,6 +54,8 @@ class GenerateHathifile
       # Move tempfile into place
       Services[:logger].info "Moving tempfile #{gzfile} -> #{outfile}"
       FileUtils.mv(gzfile, outfile)
+      Services[:logger].info "Setting 0644 permissions on #{outfile}"
+      FileUtils.chmod(0644, outfile)
     end
     fin.close
   end

--- a/jobs/generate_hathifile.rb
+++ b/jobs/generate_hathifile.rb
@@ -55,7 +55,7 @@ class GenerateHathifile
       Services[:logger].info "Moving tempfile #{gzfile} -> #{outfile}"
       FileUtils.mv(gzfile, outfile)
       Services[:logger].info "Setting 0644 permissions on #{outfile}"
-      FileUtils.chmod(0644, outfile)
+      FileUtils.chmod(0o644, outfile)
     end
     fin.close
   end

--- a/spec/jobs/generate_hathifile_spec.rb
+++ b/spec/jobs/generate_hathifile_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe GenerateHathifile do
       # The items as they were output on that day
       expected = File.read("#{__dir__}/../data/000018677-20220808.tsv")
       expect(generated).to eq(expected)
+      expect(File.stat(outfile).mode.to_s(8)[-3, 3]).to eq("644")
     end
 
     it "generates the expected output from gzipped file" do
@@ -76,6 +77,7 @@ RSpec.describe GenerateHathifile do
       # The items as they were output on that day
       expected = File.read("#{__dir__}/../data/000018677-20220808-upd.tsv")
       expect(generated).to eq(expected)
+      expect(File.stat(outfile).mode.to_s(8)[-3, 3]).to eq("644")
     end
 
     it "generates the expected output from gzipped file" do


### PR DESCRIPTION
- Fixes a bug introduced when we went with `Tempfile.create` to accumulate the output hathifile, vs just creating it in situ.
- Tempfiles are 0600 by default which is wrong for our purposes, we want them at 644 because the owner is currently `tomcatrhel5` and 0600 locks everyone out.
- Reviewer: a brief inspection and test run should be sufficient.