### PR TITLE
Addresses #18 REXML denial of service vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     rainbow (3.1.1)
     rake (13.1.0)
     regexp_parser (2.8.3)
-    rexml (3.2.9)
+    rexml (3.3.2)
       strscan
     rspec (3.12.0)
       rspec-core (~> 3.12.0)


### PR DESCRIPTION
- Manual update to patched version 3.3.2.
  - Automatic generation failed with "The latest possible version of rexml that can be installed is 3.2.9"