### PR TITLE
Dependency updates for May 2026

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -24,6 +24,6 @@ jobs:
         run: docker compose run --rm hf bundle exec rspec
 
       - name: Report to Coveralls
-        uses: coverallsapp/github-action@1.1.3
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.4 AS base
+FROM ruby:4.0 AS base
 ARG UNAME=app
 ARG UID=1000
 ARG GID=1000

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GIT
 
 GIT
   remote: https://github.com/hathitrust/hathifiles_database.git
-  revision: aee8dc197927a464f2c2c7c609f52abe33ab9103
+  revision: 5e957ef3e1f04c9aa5e74662a9ffeaa43b9cfc55
   branch: main
   specs:
-    hathifiles_database (0.5.6)
+    hathifiles_database (0.5.7)
       date_named_file
       dotenv
       ettin
@@ -23,17 +23,17 @@ GIT
 
 GIT
   remote: https://github.com/hathitrust/push_metrics.git
-  revision: 3cba728a95eb936fed5f06da028c88d06bb23996
+  revision: 197dacfa9da68059012809cb6108691da7b605f6
   branch: main
   specs:
-    push_metrics (0.10.0)
+    push_metrics (0.10.1)
       milemarker (~> 1.0)
       prometheus-client (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -46,11 +46,11 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     canister (0.9.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
@@ -69,24 +69,24 @@ GEM
     dry-cli (1.4.1)
     dry-files (1.1.0)
     dry-inflector (1.3.1)
-    erb (6.0.1)
+    erb (6.0.4)
     ettin (1.3.0)
       deep_merge
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     fast_jsonparser (0.6.0)
-    ffi (1.17.3-aarch64-linux-gnu)
-    ffi (1.17.3-x86_64-linux-gnu)
-    ffi-compiler (1.3.2)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi-compiler (1.4.2)
       ffi (>= 1.15.5)
       rake
-    hanami-cli (2.3.4)
+    hanami-cli (2.3.5)
       bundler (>= 2.1)
       dry-cli (~> 1.0, >= 1.1.0)
       dry-files (~> 1.0, >= 1.0.2)
@@ -102,7 +102,7 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.5.0)
-    http-cookie (1.1.0)
+    http-cookie (1.1.6)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     httpclient (2.9.0)
@@ -110,11 +110,12 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    irb (1.16.0)
+    irb (1.18.0)
       pp (>= 0.6.0)
+      prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.0)
+    json (2.19.5)
     language_server-protocol (3.17.0.5)
     library_stdnums (1.6.0)
     lint_roller (1.1.0)
@@ -130,19 +131,20 @@ GEM
     method_source (1.1.0)
     milemarker (1.0.2)
       logger
-    minitest (6.0.1)
+    minitest (6.0.6)
+      drb (~> 2.0)
       prism (~> 1.5)
     mutex_m (0.3.0)
     mysql2 (0.5.7)
       bigdecimal
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.19.0-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.0-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    parallel (1.27.0)
-    parser (3.3.10.1)
+    parallel (1.28.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
@@ -160,18 +162,18 @@ GEM
     psych (5.3.1)
       date
       stringio
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
-    rack (3.2.4)
+    rack (3.2.6)
     rackup (2.3.1)
       rack (>= 3)
     rainbow (3.1.1)
-    rake (13.3.1)
-    rdoc (7.1.0)
+    rake (13.4.2)
+    rdoc (7.2.0)
       erb
       psych (>= 4.0.0)
       tsort
-    regexp_parser (2.11.3)
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
@@ -184,11 +186,11 @@ GEM
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.7)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.82.1)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -196,10 +198,10 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.0)
+    rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -208,7 +210,7 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sequel (5.101.0)
+    sequel (5.104.0)
       bigdecimal
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -218,12 +220,12 @@ GEM
     simplecov-lcov (0.9.0)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
-    sqlite3 (2.9.0-aarch64-linux-gnu)
-    sqlite3 (2.9.0-x86_64-linux-gnu)
-    standard (1.53.0)
+    sqlite3 (2.9.3-aarch64-linux-gnu)
+    sqlite3 (2.9.3-x86_64-linux-gnu)
+    standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.82.0)
+      rubocop (~> 1.84.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
@@ -267,7 +269,7 @@ GEM
     uri (1.1.1)
     wisper (2.0.1)
     yell (2.2.2)
-    zeitwerk (2.7.4)
+    zeitwerk (2.7.5)
     zinzout (0.1.1)
 
 PLATFORMS
@@ -298,4 +300,4 @@ DEPENDENCIES
   zinzout
 
 BUNDLED WITH
-  4.0.5
+  4.0.11

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "factory_bot"
-require "pathname"
 require "pry"
 require "services"
 require "simplecov"


### PR DESCRIPTION
- Update Ruby 3.4 -> 4.0
- Update GitHub test `checkout` and `coverallsapp` actions
- `bundle update --bundler`
- `bundle update --all`
- Remove unneded `require` flagged by `standardrb`