### PR TITLE
ETT-1339: Update pub date table when updating hathfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,9 @@ gem "hathifiles_database", git: "https://github.com/hathitrust/hathifiles_databa
 group :development, :test do
   gem "factory_bot"
   gem "faraday"
-  gem "pry"
   gem "rspec"
   gem "simplecov"
   gem "simplecov-lcov"
   gem "standardrb"
+  gem "debug"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,12 +52,14 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     canister (0.9.2)
-    coderay (1.1.3)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     csv (3.3.5)
     date (3.5.1)
     date_named_file (0.1.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.6.2)
     docile (1.4.1)
@@ -128,7 +130,6 @@ GEM
       rexml
     marc-fastxmlwriter (1.1.0)
       marc (~> 1.0)
-    method_source (1.1.0)
     milemarker (1.0.2)
       logger
     minitest (6.0.6)
@@ -155,10 +156,6 @@ GEM
     prism (1.9.0)
     prometheus-client (4.2.5)
       base64
-    pry (0.16.0)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-      reline (>= 0.6.0)
     psych (5.3.1)
       date
       stringio
@@ -279,6 +276,7 @@ PLATFORMS
 DEPENDENCIES
   canister
   date_named_file
+  debug
   dotenv
   ettin
   factory_bot
@@ -289,7 +287,6 @@ DEPENDENCIES
   marc
   milemarker
   mysql2
-  pry
   push_metrics!
   rspec
   sequel

--- a/config/pub_date.sql
+++ b/config/pub_date.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS hf_pub_date
+  (
+    bib_num bigint PRIMARY KEY NOT NULL,
+    pub_date int
+  );
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,20 +20,22 @@ services:
       mariadb: *healthy
       pushgateway: *healthy
     environment:
-      MARIADB_HT_RO_USERNAME: ht_rights
-      MARIADB_HT_RO_PASSWORD: ht_rights
+      MARIADB_HT_RO_USERNAME: hathifiles
+      MARIADB_HT_RO_PASSWORD: hathifiles
       MARIADB_HT_RO_HOST: mariadb
       MARIADB_HT_RO_DATABASE: ht
       PUSHGATEWAY: http://pushgateway:9091
 
   mariadb:
     image: ghcr.io/hathitrust/db-image:latest
+    volumes:
+      - ./config/pub_date.sql:/docker-entrypoint-initdb.d/999-pubdate.sql
     restart: always
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: 1
       MYSQL_DATABASE: ht
-      MYSQL_USER: ht_rights
-      MYSQL_PASSWORD: ht_rights
+      MYSQL_USER: hathifiles
+      MYSQL_PASSWORD: hathifiles
     healthcheck:
       <<: *healthcheck-defaults
       test: [ "CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]

--- a/jobs/generate_hathifile.rb
+++ b/jobs/generate_hathifile.rb
@@ -9,6 +9,7 @@ require "hathifile_writer"
 require "services"
 require "settings"
 require "zephir_files"
+require "pub_date_updater"
 
 class GenerateHathifile
   attr_reader :tracker
@@ -40,9 +41,12 @@ class GenerateHathifile
       File.open(infile)
     end
     writer = HathifileWriter.new(hathifile: zephir_file.hathifile)
+    pub_dates = PubDateUpdater.new
     fin.each do |line|
-      records = BibRecord.new(line).hathifile_records.to_a
-      writer.add records
+      bib_record = BibRecord.new(line)
+      pub_dates.update(bib_record)
+      hathifile_records = bib_record.hathifile_records.to_a
+      writer.add hathifile_records
       tracker.increment_and_log_batch_line
     end
     writer.finish

--- a/lib/bib_record.rb
+++ b/lib/bib_record.rb
@@ -7,6 +7,7 @@ require "fast_jsonparser"
 require "json"
 require "place_of_publication"
 require "us_fed_doc"
+require "record_date"
 require "item_record"
 
 class BibRecord
@@ -81,6 +82,10 @@ class BibRecord
       @imprint = Traject::MarcExtractor.cached("264|*1|bc").extract(marc).map { |imp| imp.strip }
     end
     @imprint
+  end
+
+  def pub_date
+    RecordDate.get_date(marc)
   end
 
   def u_and_f?

--- a/lib/pub_date_updater.rb
+++ b/lib/pub_date_updater.rb
@@ -1,0 +1,8 @@
+class PubDateUpdater
+  def update(bib_record)
+    date = bib_record.pub_date
+    Services.db[:hf_pub_date]
+      .replace(bib_num: bib_record.ht_bib_key, 
+               pub_date: bib_record.pub_date)
+  end
+end

--- a/lib/record_date.rb
+++ b/lib/record_date.rb
@@ -1,0 +1,54 @@
+# Copied from hathitrust_catalog_indexer/lib/ht_traject/ht_macros.rb
+
+module RecordDate
+  # Some dates we're not going to bother with
+  BAD_DATE_TYPES = {
+    'n' => true,
+    # 'u' => true,
+    'b' => true
+  }.freeze
+
+  CONTAINS_FOUR_DIGITS = /(\d{4})/.freeze
+
+  # Get a date from a record, as best you can
+  # Try to get it from the 008; if not, the 260
+  def self.get_raw_date(r)
+    get_008_date(r) or get_260_date(r)
+  end
+
+  def self.get_date(r)
+    raw = get_raw_date(r)
+    convert_raw_date(raw)
+  end
+
+  def self.convert_raw_date(d)
+    return nil unless d
+
+    d.gsub(/u/, '0')
+  end
+
+  def self.bad_date_type?(ohoh8)
+    BAD_DATE_TYPES.has_key? ohoh8[6]
+  end
+
+  def self.get_008_date(r)
+    return nil unless r['008'] && (r['008'].value.size > 10)
+
+    ohoh8 = r['008'].value
+
+    return nil if bad_date_type?(ohoh8)
+
+    date = ohoh8[7..10].downcase
+    return nil if (date == '0000') || date =~ /\|/
+    return nil unless date =~ /\A\d[\du]{3}/
+
+    date
+  end
+
+  def self.get_260_date(r)
+    return nil unless r['260'] && r['260']['c']
+
+    m = CONTAINS_FOUR_DIGITS.match(r['260']['c'])
+    m && m[1]
+  end
+end

--- a/spec/jobs/generate_hathifile_spec.rb
+++ b/spec/jobs/generate_hathifile_spec.rb
@@ -121,5 +121,16 @@ RSpec.describe GenerateHathifile do
       expect(metrics).to match(/^job_last_success\S*job="generate_hathifiles"\S* \S+/m)
         .and match(/^job_records_processed\S*job="generate_hathifiles"\S* 1$/m)
     end
+
+    it "updates pub dates" do
+      Services.db[:hf_pub_date].delete
+      # One particular UC record from a day in August 2022
+      system("cp #{__dir__}/../data/000018677-20220807.json #{Settings.zephir_dir}/zephir_upd_20220807.json")
+
+      GenerateHathifile.new.run
+
+      expect(Services.db[:hf_pub_date].where(bib_num: "000018677").first[:pub_date]).to eq(1966)
+
+    end
   end
 end

--- a/spec/pub_date_updater_spec.rb
+++ b/spec/pub_date_updater_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "pub_date_updater"
+require "bib_record"
+
+RSpec.describe PubDateUpdater do
+  # catalog record id: 011338539
+  # date 2 from 008: 1976
+  let(:bibrecord) { fixture_record('bib_rec') }
+
+  before(:each) do
+    Services.db[:hf_pub_date].delete
+  end
+
+  it "adds record to the pub date table" do
+    described_class.new.update(bibrecord)
+
+    expect(Services.db[:hf_pub_date].where(bib_num: "011338539").first[:pub_date]).to eq(1976)
+  end
+
+  it "updates pub date" do
+    Services.db[:hf_pub_date].insert("011338539",1899)
+    described_class.new.update(bibrecord)
+
+    expect(Services.db[:hf_pub_date].where(bib_num: "011338539").first[:pub_date]).to eq(1976)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "factory_bot"
-require "pry"
+require "debug"
 require "services"
 require "simplecov"
 require "simplecov-lcov"
@@ -52,4 +52,8 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   config.include FactoryBot::Syntax::Methods
+end
+
+def fixture_record(tag)
+  BibRecord.new(File.read(File.dirname(__FILE__) + "/data/#{tag}.json"))
 end


### PR DESCRIPTION
We need somewhere to put title-level publication date when generating data for the collections dashboard.

While this functionality might better belong in hathifiles-database, the issue is that we need to get this date from the records themselves rather than the hathifiles; hathifiles-database runs against the hathifiles rather than the records themselves.

Still, we could perhaps expose the table via the hathifiles-database gem rather than directly using sequel here. hathifiles doesn't currently seem to be directly using any of the hathifiles-database functionality -- maybe we did it that way just so we could use the same image, I don't really recall.

I also don't love that this duplicates functionality currently in hathitrust_catalog_indexer. Another option for generating the title-level summary tables could be the solr pivot faceting, which I think is worth at least a quick try to see how it compares.