### PR TITLE
Dependency updates for August 2026

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/hathitrust/feddocs_filter.git
-  revision: 26845e3ea35989ba97604d0ad899ce9aeb1d0e2a
+  revision: cac86559eae01439cbc63448098785942bebd614
   branch: main
   specs:
     filter (0.7.5)
 
 GIT
   remote: https://github.com/hathitrust/hathifiles_database.git
-  revision: 0a39c9e8e66131ad041065c430c48e1f4d0a9b0b
+  revision: 6c455cee4fef27ef2692e1f3c01a1e15354797a9
   branch: main
   specs:
-    hathifiles_database (0.5.8)
+    hathifiles_database (0.5.9)
       date_named_file
       dotenv
       ettin
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/hathitrust/push_metrics.git
-  revision: 197dacfa9da68059012809cb6108691da7b605f6
+  revision: 4f44c2d83dd739b26d46829459a9f4192878629f
   branch: main
   specs:
     push_metrics (0.10.1)
@@ -33,7 +33,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3)
+    activesupport (8.1.3.1)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -46,21 +46,17 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.9.0)
-      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     canister (0.9.2)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
-    csv (3.3.5)
-    date (3.5.1)
+    csv (3.3.6)
     date_named_file (0.1.1)
     deep_merge (1.2.2)
     diff-lcs (1.6.2)
-    docile (1.4.1)
     domain_name (0.6.20240107)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
@@ -69,26 +65,21 @@ GEM
     dry-cli (1.4.1)
     dry-files (1.1.0)
     dry-inflector (1.3.1)
-    erb (6.0.4)
+    erb (6.0.7)
     ettin (1.3.0)
       deep_merge
-    factory_bot (6.5.6)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
-    faraday (2.14.1)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     fast_jsonparser (0.6.0)
-    ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-x86_64-linux-gnu)
-    ffi-compiler (1.4.2)
-      ffi (>= 1.15.5)
-      rake
-    hanami-cli (2.3.5)
+    hanami-cli (3.0.0)
       bundler (>= 2.1)
-      dry-cli (~> 1.0, >= 1.1.0)
+      dry-cli (~> 1.0, >= 1.4.0)
       dry-files (~> 1.0, >= 1.0.2)
       dry-inflector (~> 1.0)
       irb
@@ -97,31 +88,29 @@ GEM
       zeitwerk (~> 2.6)
     hashie (5.1.0)
       logger
-    http (5.3.1)
-      addressable (~> 2.8)
+    http-2 (1.2.1)
+    http (6.0.4)
       http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.5.0)
+      llhttp (~> 0.6.1)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    http-form_data (2.3.0)
     httpclient (2.9.0)
       mutex_m
-    i18n (1.14.8)
+    httpx (1.8.1)
+      http-2 (>= 1.2.0)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.2)
+    io-console (0.9.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.5)
-    language_server-protocol (3.17.0.5)
+    json (2.21.2)
+    language_server-protocol (3.17.0.6)
     library_stdnums (1.6.0)
     lint_roller (1.1.0)
-    llhttp-ffi (0.5.1)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
+    llhttp (0.6.2)
     logger (1.7.0)
     marc (1.4.0)
       nokogiri (~> 1.0)
@@ -139,17 +128,18 @@ GEM
       bigdecimal
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.19.3-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    parallel (1.28.0)
-    parser (3.3.11.1)
+    ostruct (0.6.3)
+    parallel (2.1.0)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pp (0.6.3)
+    pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
@@ -159,22 +149,23 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
       reline (>= 0.6.0)
-    psych (5.4.0)
-      date
-      stringio
-    public_suffix (7.0.5)
     racc (1.8.1)
     rack (3.2.6)
     rackup (2.3.1)
       rack (>= 3)
     rainbow (3.1.1)
     rake (13.4.2)
-    rdoc (7.2.0)
+    rbs (4.1.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     rexml (3.4.4)
     rspec (3.13.2)
@@ -190,18 +181,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.7)
-    rubocop (1.84.2)
+    rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
-      parallel (~> 1.10)
+      parallel (>= 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
       rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.49.1)
+    rubocop-ast (1.50.0)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
     rubocop-performance (1.26.1)
@@ -210,22 +201,17 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sequel (5.105.0)
+    sequel (5.107.0)
       bigdecimal
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
+    simplecov (1.0.3)
     simplecov-lcov (0.9.0)
-    simplecov_json_formatter (0.1.4)
     slop (4.10.1)
     sqlite3 (2.9.5-aarch64-linux-gnu)
     sqlite3 (2.9.5-x86_64-linux-gnu)
-    standard (1.54.0)
+    standard (1.56.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
-      rubocop (~> 1.84.0)
+      rubocop (~> 1.88.0)
       standard-custom (~> 1.0.0)
       standard-performance (~> 1.8)
     standard-custom (1.0.2)
@@ -236,14 +222,15 @@ GEM
       rubocop-performance (~> 1.26.0)
     standardrb (1.0.1)
       standard
-    stringio (3.2.0)
-    traject (3.8.3)
+    traject (3.9.1)
+      base64
       concurrent-ruby (>= 0.8.0)
       csv
       dot-properties (>= 0.1.1)
       hashie (>= 3.1, < 6)
-      http (>= 3.0, < 6)
+      http (>= 3.0, < 7)
       httpclient (~> 2.5)
+      httpx (~> 1.4)
       marc (~> 1.0)
       marc-fastxmlwriter (~> 1.0)
       mutex_m
@@ -269,8 +256,9 @@ GEM
     uri (1.1.1)
     wisper (2.0.1)
     yell (2.2.2)
-    zeitwerk (2.8.2)
-    zinzout (0.1.1)
+    zeitwerk (2.8.3)
+    zinzout (0.1.3)
+      ostruct
 
 PLATFORMS
   aarch64-linux
@@ -300,4 +288,4 @@ DEPENDENCIES
   zinzout
 
 BUNDLED WITH
-  4.0.11
+  4.0.18

--- a/lib/hathifile_writer.rb
+++ b/lib/hathifile_writer.rb
@@ -97,11 +97,11 @@ class HathifileWriter
       .select(:namespace, :id, :time, :access_profile)
       .where([:namespace, :id] => split_htids)
       .each do |record|
-        htid = record[:namespace] + "." + record[:id]
-        htids_to_rights[htid] = {
-          rights_timestamp: record[:time],
-          access_profile: @access_profiles[record[:access_profile]][:name]
-        }
+      htid = record[:namespace] + "." + record[:id]
+      htids_to_rights[htid] = {
+        rights_timestamp: record[:time],
+        access_profile: @access_profiles[record[:access_profile]][:name]
+      }
     end
     htids_to_rights
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "services"
 require "simplecov"
 require "simplecov-lcov"
 
-SimpleCov.add_filter "spec"
+SimpleCov.skip "spec"
 
 SimpleCov::Formatter::LcovFormatter.config do |c|
   c.report_with_single_file = true


### PR DESCRIPTION
- `bundle update --bundler`
- `bundle update --all`
- Update `hathitrust_contrib_configs` submodule to latest
- Fix indentation issue in `HathifileWriter` newly uncovered by `standardrb`
- Fix `SimpleCov` `add_filter` deprecation