### PR TITLE
Fix submodules input in build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,5 +41,5 @@ jobs:
             push_latest: ${{ inputs.push_latest}}
             rebuild: ${{ inputs.rebuild }}
             platforms: ${{ inputs.platforms }}
-            submodules: recursive
+            submodules: true
         secrets: inherit


### PR DESCRIPTION
Replace "recursive" with true.

I built `dea4989b50310914bddadd2cd98cae817383b074` with this and verified from the logs it is getting the needed submodule. I am going to go ahead and build/tag/deploy with this branch.