### PR TITLE
ETT-1612 fixes

### DIFF
--- a/lib/solr_pivot_facets.rb
+++ b/lib/solr_pivot_facets.rb
@@ -46,7 +46,7 @@ class SolrPivotFacets
   end
 
   def solr_connection
-    Faraday.new(solr_facets_url) do |f|
+    Faraday.new(solr_facets_url, request: {timeout: 120}) do |f|
       f.headers["Accept"] = "application/json"
     end
   end

--- a/lib/title_summary_table.rb
+++ b/lib/title_summary_table.rb
@@ -36,7 +36,7 @@ class TitleSummaryTable
         publication_place VARCHAR(128),
         us_gov_doc_flag tinyint(4),
         total_unique_titles bigint(21)
-      );
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
     SQL
   end
 


### PR DESCRIPTION
- Production reported `Incorrect string value: '\xCC\x84hjah...'` for a pub place field with Unicode.
  - Add `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci` to the table creation SQL.
- Testing reported a timeout talking to Solr, from the logs it looks like a 60 second timeout.
  - Try setting Faraday to a 120 second timeout (solrcloud may be less responsive?)